### PR TITLE
SecretScannerBot: Create detected secrets baseline

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,82 @@
+{
+  "custom_plugin_paths": [],
+  "exclude": {
+    "files": null,
+    "lines": null
+  },
+  "generated_at": "2021-03-10T20:32:21Z",
+  "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": null,
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "results": {
+    "test.py": [
+      {
+        "hashed_secret": "b0399d2029f64d445bd131ffaa399a42d2f8e7dc",
+        "is_verified": false,
+        "line_number": 1,
+        "type": "Secret Keyword"
+      },
+      {
+        "hashed_secret": "7c6a61c68ef8b9b6b061b28c348bc1ed7921cb53",
+        "is_verified": false,
+        "line_number": 3,
+        "type": "Secret Keyword"
+      }
+    ]
+  },
+  "version": "0.14.3",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
+}


### PR DESCRIPTION
<p>Create <code>.secrets.baseline</code> file in the repository root. </p> <p> The SRE team's SecretScannerBot scans every repository within SmileDirectClub and creates a baseline for potential secrets within each repository. </p> <p> Please review and allow updates to this file in order to maintain up-to-date security. </p> <p> For more information, see <a href= 'https://smiledirectclub.atlassian.net/wiki/spaces/S/pages/1672315049/Detect+Secrets'> Detect Secrets </a> </p> <p> Once merged, you may view the results at <a href='https://secret-scanner.us-east-2.fluoride.sdcops.com/#/eliecer-daza-tests/testing-ss-sdc'>https://secret-scanner.us-east-2.fluoride.sdcops.com/#/eliecer-daza-tests/testing-ss-sdc</a> </p>